### PR TITLE
Season 10, Week 3 Correction

### DIFF
--- a/season-10/matches/mnp-10-3-CHS-DTP.json
+++ b/season-10/matches/mnp-10-3-CHS-DTP.json
@@ -130,7 +130,8 @@
     "confirmed": {
       "by": "Alex Skinner",
       "at": 1537847194115
-    }
+    },
+    "key": "CHS"
   },
   "home": {
     "name": "Stranger Slings",
@@ -220,7 +221,8 @@
     "confirmed": {
       "by": "Jesse Mullene",
       "at": 1537847315647
-    }
+    },
+    "key": "DTP"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-CPO-ETB.json
+++ b/season-10/matches/mnp-10-3-CPO-ETB.json
@@ -111,7 +111,8 @@
     "confirmed": {
       "by": "Aaron Garberding",
       "at": 1537847704100
-    }
+    },
+    "key": "CPO"
   },
   "home": {
     "name": "18-Ball Deluxe",
@@ -201,7 +202,8 @@
     "confirmed": {
       "by": "Anthony Welters",
       "at": 1537847317727
-    }
+    },
+    "key": "ETB"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-DSV-SJK.json
+++ b/season-10/matches/mnp-10-3-DSV-SJK.json
@@ -112,7 +112,8 @@
     "confirmed": {
       "by": "Ari Golding",
       "at": 1537847194020
-    }
+    },
+    "key": "DSV"
   },
   "home": {
     "name": "Soda Jerks",
@@ -202,7 +203,8 @@
     "confirmed": {
       "by": "Zac Petersen",
       "at": 1537847302084
-    }
+    },
+    "key": "SJK"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-FRZ-CDC.json
+++ b/season-10/matches/mnp-10-3-FRZ-CDC.json
@@ -111,7 +111,8 @@
     "confirmed": {
       "by": "Aaron Bendickson",
       "at": 1537847556722
-    }
+    },
+    "key": "FRZ"
   },
   "home": {
     "name": "Contras",
@@ -201,7 +202,8 @@
     "confirmed": {
       "by": "Maureen Hendrix",
       "at": 1537847569133
-    }
+    },
+    "key": "CDC"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-HHS-SCN.json
+++ b/season-10/matches/mnp-10-3-HHS-SCN.json
@@ -111,7 +111,8 @@
     "confirmed": {
       "by": "Claire Burke",
       "at": 1537847743621
-    }
+    },
+    "key": "HHS"
   },
   "home": {
     "name": "Seacorns",
@@ -197,7 +198,8 @@
     "confirmed": {
       "by": "Megan Czahar",
       "at": 1537847849938
-    }
+    },
+    "key": "SCN"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-IBL-SWL.json
+++ b/season-10/matches/mnp-10-3-IBL-SWL.json
@@ -129,7 +129,8 @@
     "confirmed": {
       "by": "Matt Anderson WA",
       "at": 1537847132664
-    }
+    },
+    "key": "IBL"
   },
   "home": {
     "name": "Specials When Lit",
@@ -219,7 +220,8 @@
     "confirmed": {
       "by": "Jared Gamble",
       "at": 1537847219952
-    }
+    },
+    "key": "SWL"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-JMF-KNR.json
+++ b/season-10/matches/mnp-10-3-JMF-KNR.json
@@ -131,7 +131,8 @@
     "confirmed": {
       "by": "Stephen Rakonza",
       "at": 1537847945771
-    }
+    },
+    "key": "JMF"
   },
   "home": {
     "name": "Knight Riders",
@@ -221,7 +222,8 @@
     "confirmed": {
       "by": "Phil Harmonic",
       "at": 1537847968102
-    }
+    },
+    "key": "KNR"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-LNL-DIH.json
+++ b/season-10/matches/mnp-10-3-LNL-DIH.json
@@ -117,7 +117,8 @@
     "confirmed": {
       "by": "Daniel Reddin",
       "at": 1537847116039
-    }
+    },
+    "key": "LNL"
   },
   "home": {
     "name": "Drain in Hell",
@@ -207,7 +208,8 @@
     "confirmed": {
       "by": "Zak Geier",
       "at": 1537847716467
-    }
+    },
+    "key": "DIH"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-PGN-RMS.json
+++ b/season-10/matches/mnp-10-3-PGN-RMS.json
@@ -110,7 +110,8 @@
     "confirmed": {
       "by": "Nif Ward",
       "at": 1537846595269
-    }
+    },
+    "key": "PGN"
   },
   "home": {
     "name": "Magic Saves",
@@ -200,7 +201,8 @@
     "confirmed": {
       "by": "Anthony McCammant",
       "at": 1537846806928
-    }
+    },
+    "key": "RMS"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-PKT-LLK.json
+++ b/season-10/matches/mnp-10-3-PKT-LLK.json
@@ -106,7 +106,8 @@
       }
     ],
     "ready": false,
-    "confirmed": false
+    "confirmed": false,
+    "key": "PKT"
   },
   "home": {
     "name": "Lucky Lickers",
@@ -196,7 +197,8 @@
     "confirmed": {
       "by": "Justina Russo",
       "at": 1537847752873
-    }
+    },
+    "key": "LLK"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-SSS-PBR.json
+++ b/season-10/matches/mnp-10-3-SSS-PBR.json
@@ -118,7 +118,8 @@
     "confirmed": {
       "by": "Hayden McCabe",
       "at": 1537847711373
-    }
+    },
+    "key": "SSS"
   },
   "home": {
     "name": "Point Breakers",
@@ -208,7 +209,8 @@
     "confirmed": {
       "by": "Heather Loudon",
       "at": 1537847440122
-    }
+    },
+    "key": "PBR"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-TBT-CRA.json
+++ b/season-10/matches/mnp-10-3-TBT-CRA.json
@@ -99,7 +99,8 @@
       }
     ],
     "ready": false,
-    "confirmed": false
+    "confirmed": false,
+    "key": "TBT"
   },
   "home": {
     "name": "Castle Crashers",
@@ -185,7 +186,8 @@
     "confirmed": {
       "by": "Tyler Morgan",
       "at": 1537848471761
-    }
+    },
+    "key": "CRA"
   },
   "rounds": [
     {

--- a/season-10/matches/mnp-10-3-TWC-NLT.json
+++ b/season-10/matches/mnp-10-3-TWC-NLT.json
@@ -114,7 +114,8 @@
     "confirmed": {
       "by": "Taylor Minter",
       "at": 1537846863942
-    }
+    },
+    "key": "TWC"
   },
   "home": {
     "name": "Northern Lights",
@@ -197,7 +198,8 @@
     "confirmed": {
       "by": "Alexa Philbeck",
       "at": 1537846854840
-    }
+    },
+    "key": "NLT"
   },
   "rounds": [
     {


### PR DESCRIPTION
The spawn script did not add team keys to the matches. That coincidentally crashed the get-standings function.