### PR TITLE
Fix for Matchplay Ratings 1250 bug; added players

### DIFF
--- a/season-12/IPR.csv
+++ b/season-12/IPR.csv
@@ -73,6 +73,7 @@
 1,Banjo Mike
 2,Barry Kornegay
 1,Ben Flaster
+1,Ben Futrell
 4,Benton Seybold
 1,Beth Petrick
 1,Bethany Brakemeyer
@@ -139,7 +140,7 @@
 1,Chelsey Oedewaldt
 2,Chelsie Hulka
 2,Chico Santana
-1,Chloe Crumbliss
+1,Chole Crumbliss
 4,Chris Borgstadt
 2,Chris Bronson
 6,Chris Chinn
@@ -166,9 +167,11 @@
 4,Corbin Sheffels
 2,Corey Barreras
 1,Corey Klier
+1,Corey Turley
 3,Cory Lampe
 2,Cory Moormeier
 3,Craig Cainkar
+1,Craig Geaschel
 3,Craig R Jones
 1,Cristian Pecile
 1,Croix Frigo
@@ -176,8 +179,9 @@
 1,Dan Crowdus
 4,Dan Danger
 3,Dan Mclane
+1,Dana Harper
 3,Danae Hackett
-1,Dane Hjeresen
+3,Dane Hjeresen
 1,Daniel Marino
 2,Daniel Mays
 2,Daniel Miller WA
@@ -242,6 +246,7 @@
 3,Evan Adkins
 2,Evan Eckles
 2,Evan McBride
+2,Evan Seftel
 1,Evan Severson
 5,Fabian Benabente
 1,Fernando Pizarro
@@ -279,7 +284,7 @@
 1,Heather Shypula
 3,Heather Willott
 3,Honi Harrison
-1,Ian Spicknal
+2,Ian Spicknal
 3,Illirik Smirnov
 2,Isaac Grams
 1,Isaac Harney
@@ -290,6 +295,7 @@
 1,Jackson Ryan
 1,Jacob Bevan
 1,Jacob Ricker
+2,Jake Beckerman
 1,Jake Cochrane
 5,Jake Hei
 1,James Brown
@@ -343,6 +349,7 @@
 1,Jesse Rinehart
 1,Jessica Dengler
 1,Jim Edwards
+1,Jim Henderson
 1,Jim Suplizio
 1,Jocye Hamilton
 2,Jodine Hatfield
@@ -357,6 +364,7 @@
 6,John Robinson WA
 2,John Tierney
 5,Johnny Hill
+2,Jon Jow
 6,Jon Salzman
 5,Jon Shaiman
 2,Jonathan Hawthorne
@@ -417,7 +425,7 @@
 1,Kylie Waibel
 4,Landon Martin WA
 4,Lane Hill
-2,Laura Bodine
+2,Laura Minter
 1,Laura Hale
 1,Lauren Aiello
 3,Lauren Aquino
@@ -455,7 +463,7 @@
 3,Mark Demmel
 2,Mark Licastro
 1,Mark McClure
-1,Mark Ostler
+2,Mark Ostler
 2,Mark Rueter
 3,Mark Williams WA
 2,Mark Wistrom
@@ -489,6 +497,7 @@
 2,Max Stiles
 4,Megan Czahar
 2,Meghan West
+1,Melaina Robertson
 1,Melissa Miller
 1,Meral Husnein
 1,Mia Shaughnessy
@@ -513,7 +522,7 @@
 1,Mike Morton
 1,Mike Norman
 6,Mike Pantoliano
-1,Mike Poetzel
+2,Mike Poetzel
 5,Mitchell D. Anderson
 1,Molly Foster
 2,Nate Cantor
@@ -574,6 +583,7 @@
 1,Rebekah MacNeil
 1,Reggie Tanner
 4,Ren Logan
+1,Renee Hwang
 2,Rhett Pearson
 1,Richard Pugh
 1,Richard Scott
@@ -606,6 +616,7 @@
 1,Sarah Decory
 4,Sarah Hager
 1,Sarah Ledray
+1,Scott Helgason
 1,Scott Kulick
 1,Sean Carlson
 2,Sean Detore
@@ -662,7 +673,7 @@
 2,Tom Walsh
 2,Tomar Schell
 1,Tony Bacus
-1,Tony Mitchum
+3,Tony Mitchum
 4,Travis Grimes
 3,Travis Johnson
 5,Travis Maisch
@@ -695,4 +706,5 @@
 1,Zack Speron
 2,Zak Geier
 2,Zeke Gough
+4,Zofia Gil
 1,Zolaire


### PR DESCRIPTION
Some ratings changed from 1 to 2, or 1 to 3, because of the bug that gave default Matchplay Ratings at 1250. Also looked up and added new subs from weeks 1 and 2 of season 12. And fixed Chole Crumbliss spelling, and Laura Minter who is still Laura Bodine in IFPA (she needs to change that with them).

Did not add "Kitty" who subbed in week one for JMF because I don't know who or what that is. ;-) If they reappear we need to get an actual name for them.